### PR TITLE
Fix to_code: Swap behavior based on PY_GTE_3_9

### DIFF
--- a/cdd/shared/ast_utils.py
+++ b/cdd/shared/ast_utils.py
@@ -1356,9 +1356,9 @@ def _to_code(node):
     """
 
     return (
-        getattr(import_module("astor"), "to_source")
+        getattr(import_module("ast"), "unparse")
         if PY_GTE_3_9
-        else getattr(import_module("ast"), "unparse")
+        else getattr(import_module("astor"), "to_source")
     )(node)
 
 


### PR DESCRIPTION
Original Code imported unparse from ast when python_version was NOT 3.9, when it should have been the opposite as the unparse function was introduced in Python 3.9.